### PR TITLE
ci: update markdown formatter action to use stable version tag `v1`.

### DIFF
--- a/.github/workflows/markdown-auto-formatter.yml
+++ b/.github/workflows/markdown-auto-formatter.yml
@@ -11,6 +11,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: minvws/action-markdown-formatter@7140c0fcd5b26e267e4744bb160c69bb0b9997e4
+      - uses: minvws/action-markdown-formatter@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updated the markdown formatter action in `markdown-auto-formatter.yml` to use tag `v1`.