### PR TITLE
chore: avoid rate-limiting when processing multiple files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/action.yml
+++ b/action.yml
@@ -76,4 +76,6 @@ runs:
             exit 1
           fi
           echo "Successfully committed change for $FILE"
+          echo "Waiting 2s before processing the next file..."
+          sleep 2
         done < <(git ls-files -m -z)


### PR DESCRIPTION
Avoid rate-limiting when processing multiple files
- Add a 2-second delay between processing files in `action.yml`.
- Related to this issue https://github.com/minvws/rdo-icore-docs/actions/runs/19886100167/job/56993573463
- Add dependabot default cooldown period, related to https://github.com/minvws/rdo-icore-coordination/issues/313